### PR TITLE
Change to https:// in API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -154,7 +154,7 @@ $ curl "https://api.censusreporter.org/2.0/table/latest/B01001A"
  `y`             | int    | Yes       | The y value for the tile.
 
 Returns a [GeoJSON](
-//geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
+http://geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
 
 #### `GET /1.0/geo/<release>/<geoid>`
 

--- a/API.md
+++ b/API.md
@@ -22,7 +22,7 @@ Returns information about the specified tabulation. A tabulation is a grouping o
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/1.0/tabulation/01001"
+$ curl "https://api.censusreporter.org/1.0/tabulation/01001"
 {
     "tabulation_code": "01001",
     "table_title": "Sex by Age",
@@ -70,7 +70,7 @@ Returns information about the specified table in the specified release. Informat
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/1.0/table/B01001A"
+$ curl "https://api.censusreporter.org/1.0/table/B01001A"
 {
     "table_id": "B01001A",
     "table_title": "Sex by Age (White Alone)",
@@ -112,7 +112,7 @@ The `acs` parameter specifies which release to use. If you aren't sure, use the 
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/2.0/table/latest/B01001A"
+$ curl "https://api.censusreporter.org/2.0/table/latest/B01001A"
 {
     "table_id": "B01001A",
     "table_title": "Sex by Age (White Alone)",
@@ -153,7 +153,8 @@ $ curl "http://api.censusreporter.org/2.0/table/latest/B01001A"
  `x`             | int    | Yes       | The x value for the tile.
  `y`             | int    | Yes       | The y value for the tile.
 
-Returns a [GeoJSON](http://geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
+Returns a [GeoJSON](
+//geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
 
 #### `GET /1.0/geo/<release>/<geoid>`
 
@@ -170,7 +171,7 @@ Returns a [GeoJSON](http://geojson.org/) representation of the specified Census 
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/1.0/geo/tiger2015/04000US55"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2015/04000US55"
 {
     "geometry": null,
     "type": "Feature",
@@ -185,7 +186,7 @@ $ curl "http://api.censusreporter.org/1.0/geo/tiger2015/04000US55"
     }
 }
 
-$ curl "http://api.censusreporter.org/1.0/geo/tiger2015/04000US55?geom=true"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2015/04000US55?geom=true"
 {
     "geometry": {
         "type": "MultiPolygon",
@@ -229,7 +230,7 @@ This endpoint will also return the specified geography with a `relation` of `thi
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/1.0/geo/tiger2015/04000US55/parents"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2015/04000US55/parents"
 {
     "parents": [
         {
@@ -333,7 +334,7 @@ The `acs` parameter specifies which release to use. If you aren't sure, use the 
 
 Examples:
 ```bash
-$ curl "http://api.censusreporter.org/1.0/data/show/latest?table_ids=B13016&geo_ids=04000US55"
+$ curl "https://api.censusreporter.org/1.0/data/show/latest?table_ids=B13016&geo_ids=04000US55"
 {
     "release": {
         "id": "acs2013_1yr",

--- a/API.md
+++ b/API.md
@@ -153,8 +153,7 @@ $ curl "https://api.censusreporter.org/2.0/table/latest/B01001A"
  `x`             | int    | Yes       | The x value for the tile.
  `y`             | int    | Yes       | The y value for the tile.
 
-Returns a [GeoJSON](
-http://geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
+Returns a [GeoJSON](http://geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
 
 #### `GET /1.0/geo/<release>/<geoid>`
 


### PR DESCRIPTION
Getting a 301 error when using `http://` as the prefix with `curl` commands. Rendered properly in the web browser and was limited to `curl` (did not try `wget`). Changing to `https://` for a secure and 301-free user experience.