### PR TITLE
don't return Louisville (160) as a parent geography because it isn't …

### DIFF
--- a/census_extractomatic/api.py
+++ b/census_extractomatic/api.py
@@ -512,6 +512,11 @@ def special_case_parents(geoid, levels):
             'geoid': '04000US51'
         })
 
+    # Louisville is not in Census 160 data but 170 consolidated city is equivalent
+    # we could try to convert 160 L-ville into 170, but that would overlap with
+    # 050 Jefferson  which should already be in there so we'll just pluck it out.
+    levels = [level for level in levels if not level['geoid'] == '16000US2148000']
+
     return levels
 
 def compute_profile_item_levels(geoid):


### PR DESCRIPTION
Related to #24 -- the absence of Louisville (160) generated 500 errors in the main application when census tracts or other child geographies were pulled. I used the `special_case_parents` method to just pull it out in those cases. 

It's a hack, yes.