### PR TITLE
Update tigers readme with note and uri change

### DIFF
--- a/API.md
+++ b/API.md
@@ -170,7 +170,7 @@ Returns a [GeoJSON](http://geojson.org/) representation of the Census geography 
 
 Examples:
 ```bash
-$ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2020/04000US55"
 {
     "geometry": null,
     "type": "Feature",
@@ -185,7 +185,7 @@ $ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55"
     }
 }
 
-$ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55?geom=true"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2020/04000US55?geom=true"
 {
     "geometry": {
         "type": "Polygon",
@@ -212,6 +212,10 @@ $ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55?geom=true"
 }
 ```
 
+#### Note
+Every since and then, the tigers are deprecated. If by the time you are reading this documentation the endpoint returns a message such as "error Unknown TIGER release", try replacing the year part of the URl by the consecutive year one. e.g: /`tiger2020`/04000US55 does not work, then try using  /`tiger2021`/04000US55
+
+
 #### `GET /1.0/geo/<release>/<geoid>/parents`
 
  URL Argument    | Type   | Required? | Description
@@ -227,7 +231,7 @@ This endpoint will also return the specified geography with a `relation` of `thi
 
 Examples:
 ```bash
-$ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55/parents"
+$ curl "https://api.censusreporter.org/1.0/geo/tiger2020/04000US55/parents"
 {
     "parents": [
         {
@@ -247,7 +251,7 @@ $ curl "https://api.censusreporter.org/1.0/geo/tiger2016/04000US55/parents"
     ]
 }
 
-$ curl "http://api.censusreporter.org/1.0/geo/tiger2016/16000US1714000/parents"
+$ curl "http://api.censusreporter.org/1.0/geo/tiger2020/16000US1714000/parents"
 {
     "parents": [
         {

--- a/API.md
+++ b/API.md
@@ -155,6 +155,8 @@ $ curl "https://api.censusreporter.org/2.0/table/latest/B01001A"
 
 Returns a [GeoJSON](http://geojson.org/) representation of all geographies at summary level `sumlevel` and contained within a [map tile](http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/) specified by the `zoom`, `x`, and `y` parameters. You can use this to create a map of Census geographies on top of an existing map. The returned GeoJSON data includes attributes for the name and geoid of the geography.
 
+The `release` parameter specifies the TIGER release to use. Since the TIGER data is pretty expensive to keep around, Census Reporter typically only maintains the TIGER release that corresponds with the current ACS year.
+
 #### `GET /1.0/geo/<release>/<geoid>`
 
  URL Argument    | Type   | Required? | Description
@@ -167,6 +169,8 @@ Returns a [GeoJSON](http://geojson.org/) representation of all geographies at su
  `geom`         | bool   | No        | Whether or not to include the geography portion of the GeoJSON.
 
 Returns a [GeoJSON](http://geojson.org/) representation of the Census geography specified by the `geoid` parameter. By default, the returned GeoJSON only contains the attributes for the geography (including the land and water area, name, and geography ID). You can include the geography by setting the `geom` query argument to `true`. Note that this will usually make the response significantly larger, but will allow you to draw it on a map.
+
+The `release` parameter specifies the TIGER release to use. Since the TIGER data is pretty expensive to keep around, Census Reporter typically only maintains the TIGER release that corresponds with the current ACS year.
 
 Examples:
 ```bash
@@ -212,10 +216,6 @@ $ curl "https://api.censusreporter.org/1.0/geo/tiger2020/04000US55?geom=true"
 }
 ```
 
-#### Note
-Every since and then, the tigers are deprecated. If by the time you are reading this documentation the endpoint returns a message such as "error Unknown TIGER release", try replacing the year part of the URl by the consecutive year one. e.g: /`tiger2020`/04000US55 does not work, then try using  /`tiger2021`/04000US55
-
-
 #### `GET /1.0/geo/<release>/<geoid>/parents`
 
  URL Argument    | Type   | Required? | Description
@@ -228,6 +228,8 @@ Returns a list of geographies that might be considered the parent of the specifi
 In some cases, the requested geography sits in multiple parents of the same summary level. In these cases, the `coverage` attribute returned for each parent of the same summary level will specify how much of this geography sits inside that parent geography (in percent).
 
 This endpoint will also return the specified geography with a `relation` of `this`.
+
+The `release` parameter specifies the TIGER release to use. Since the TIGER data is pretty expensive to keep around, Census Reporter typically only maintains the TIGER release that corresponds with the current ACS year.
 
 Examples:
 ```bash
@@ -315,6 +317,8 @@ Returns a [GeoJSON](http://geojson.org/) representation of the specified comma-s
 The data included will always have the geography data included. Unlike the single-geography request above you cannot disable geography representation in the response.
 
 The attributes in the response will only include the geography name and the geoid.
+
+The `release` parameter specifies the TIGER release to use. Since the TIGER data is pretty expensive to keep around, Census Reporter typically only maintains the TIGER release that corresponds with the current ACS year.
 
 ### Data Retrieval
 


### PR DESCRIPTION
## Description
1. Change the tigger examples URI for the current available one
2. Added a note to warm the people when 2020 becomes deprecated to try out the next available one

## Note in readme
<img width="723" alt="Screen Shot 2022-04-06 at 19 30 11" src="https://user-images.githubusercontent.com/6934447/162097006-36735798-5f38-4fa6-bf2b-49e57ca78b54.png">
