### PR TITLE
Arbitrary-geometry ACS aggregation endpoint (with proper MoE)

### DIFF
--- a/census_extractomatic/aggregate_acs.py
+++ b/census_extractomatic/aggregate_acs.py
@@ -1,0 +1,88 @@
+"""Database-independent orchestration for aggregating ACS tables across a set of
+component geographies that overlap a user's arbitrary geometry.
+
+The spatial selection and data fetching live in the Flask API layer; this module
+takes already-fetched component data plus table metadata and produces aggregated
+estimates and margins of error, refusing to aggregate statistics that are not
+additive across geographies (medians, means, per-capita, index values).
+"""
+from census_extractomatic.moe import aggregate_count
+
+# Keywords in a table or column title that mark a statistic as NOT additive
+# across geographies. "Aggregate" is deliberately excluded: aggregate totals
+# (e.g. Aggregate Household Income) are plain sums and CAN be combined.
+_NON_ADDITIVE_KEYWORDS = (
+    ("median", "Medians cannot be aggregated across geographies."),
+    ("mean", "Means cannot be aggregated across geographies."),
+    ("per capita", "Per-capita values cannot be aggregated across geographies."),
+    ("gini", "Index values cannot be aggregated across geographies."),
+)
+
+
+def suppression_reason(table_title, column_title):
+    """Return a human-readable reason string if the given column is NOT additive
+    across geographies (and therefore must not be summed), or None if it is a
+    plain count that can be aggregated."""
+    haystack = "{} {}".format(table_title or "", column_title or "").lower()
+    for keyword, reason in _NON_ADDITIVE_KEYWORDS:
+        if keyword in haystack:
+            return reason
+    return None
+
+
+def aggregate_tables(components, metadata):
+    """Aggregate ACS tables across a list of component geographies.
+
+    ``components`` is a list (one entry per component geography) shaped like the
+    per-geography portion of the ``/1.0/data/show`` response::
+
+        {table_id: {"estimate": {col: value}, "error": {col: value}}}
+
+    ``metadata`` maps table_id -> {"title", "denominator_column_id", "columns":
+    {col: {"name": column_title}}}.
+
+    Returns, per table::
+
+        {table_id: {"title", "estimate": {col: sum},
+                    "error": {col: moe}, "suppressed": [{"column_id", "reason"}]}}
+
+    Count columns are summed with the Census zero-estimate rule. Non-additive
+    columns (medians, means, per-capita, index) are never summed; they are listed
+    in ``suppressed`` instead.
+    """
+    result = {}
+    for table_id, table_meta in metadata.items():
+        table_title = table_meta.get("title")
+        columns = table_meta.get("columns", {})
+
+        estimates = {}
+        errors = {}
+        suppressed = []
+
+        for column_id, column_meta in columns.items():
+            column_title = (column_meta or {}).get("name")
+            reason = suppression_reason(table_title, column_title)
+            if reason is not None:
+                suppressed.append({"column_id": column_id, "reason": reason})
+                continue
+
+            col_estimates = []
+            col_moes = []
+            for component in components:
+                table_data = component.get(table_id)
+                if not table_data:
+                    continue
+                col_estimates.append(table_data["estimate"][column_id])
+                col_moes.append(table_data["error"][column_id])
+
+            est, moe = aggregate_count(col_estimates, col_moes)
+            estimates[column_id] = est
+            errors[column_id] = moe
+
+        result[table_id] = {
+            "title": table_title,
+            "estimate": estimates,
+            "error": errors,
+            "suppressed": suppressed,
+        }
+    return result

--- a/census_extractomatic/aggregate_acs.py
+++ b/census_extractomatic/aggregate_acs.py
@@ -30,6 +30,28 @@ def suppression_reason(table_title, column_title):
     return None
 
 
+def select_components(rows, threshold=0.0):
+    """Filter spatial-intersection rows down to the component geographies that
+    should be included in the aggregate.
+
+    ``rows`` are mappings with ``full_geoid``, ``display_name`` and
+    ``area_frac`` (the fraction of the geography's own area inside the shape).
+    A geography is included when ``area_frac >= threshold``. With the default
+    threshold of 0.0, every geography the shape intersects is kept.
+
+    Returns a list of {"geoid", "name", "area_frac"} dicts, order preserved.
+    """
+    components = []
+    for row in rows:
+        if row["area_frac"] >= threshold:
+            components.append({
+                "geoid": row["full_geoid"],
+                "name": row["display_name"],
+                "area_frac": row["area_frac"],
+            })
+    return components
+
+
 def aggregate_tables(components, metadata):
     """Aggregate ACS tables across a list of component geographies.
 
@@ -72,8 +94,14 @@ def aggregate_tables(components, metadata):
                 table_data = component.get(table_id)
                 if not table_data:
                     continue
-                col_estimates.append(table_data["estimate"][column_id])
-                col_moes.append(table_data["error"][column_id])
+                est_value = table_data["estimate"][column_id]
+                moe_value = table_data["error"][column_id]
+                # A release may have no value for a column in a given geography;
+                # leave that component out of this column rather than crash.
+                if est_value is None or moe_value is None:
+                    continue
+                col_estimates.append(est_value)
+                col_moes.append(moe_value)
 
             est, moe = aggregate_count(col_estimates, col_moes)
             estimates[column_id] = est

--- a/census_extractomatic/api.py
+++ b/census_extractomatic/api.py
@@ -1820,6 +1820,12 @@ def aggregate_acs_geometry(release):
     component_data = [data[g] for g in geo_ids if g in data]
     aggregated = aggregate_tables(component_data, table_metadata)
 
+    # Flatten column metadata so the client can label columns and indent them.
+    column_meta = OrderedDict()
+    for table in table_metadata.values():
+        for column_id, col in table['columns'].items():
+            column_meta[column_id] = col
+
     resp = jsonify(
         release=release,
         release_name=ACS_NAMES.get(release, {}).get('name', release),
@@ -1827,6 +1833,7 @@ def aggregate_acs_geometry(release):
         threshold=threshold,
         components=components,
         tables=aggregated,
+        column_meta=column_meta,
     )
     resp.cache_control.max_age = 15
     resp.cache_control.public = True

--- a/census_extractomatic/api.py
+++ b/census_extractomatic/api.py
@@ -50,6 +50,10 @@ from .user_geo import (
     fetch_user_geog_as_geojson,
     create_aggregate_download,
 )
+from census_extractomatic.aggregate_acs import (
+    select_components,
+    aggregate_tables,
+)
 from census_extractomatic.full_text_search import perform_full_text_search
 
 from census_extractomatic.exporters import supported_formats
@@ -1649,6 +1653,184 @@ def show_specified_data(acs):
             app.logger.debug(f"[release {release_to_use}] [table {','.join(valid_table_ids)}] missing data for [{','.join(missing_geos)}]")
 
     return abort(400, "None of the releases had the requested geo_ids and table_ids")
+
+
+# --- Arbitrary-geometry ACS aggregation -------------------------------------
+# Combine ACS estimates (and propagate margins of error) across the census
+# geographies of a chosen summary level that overlap a user-supplied polygon.
+# See census_extractomatic/aggregate_acs.py and moe.py for the aggregation math.
+
+# Fraction of a source geography's own area that must fall inside the shape
+# is computed here; the planar (degree) area is fine because only the RATIO is
+# used, and the threshold is an approximate inclusion knob.
+AGGREGATE_INTERSECT_SQL = """
+SELECT nl.full_geoid,
+       nl.display_name,
+       ST_Area(ST_Intersection(nl.geom, poly.g)) / NULLIF(ST_Area(nl.geom), 0) AS area_frac
+  FROM {tiger}.census_name_lookup nl,
+       (SELECT ST_SetSRID(ST_GeomFromGeoJSON(:geojson), 4326) AS g) poly
+ WHERE nl.sumlevel = :sumlevel
+   AND ST_Intersects(nl.geom, poly.g)
+"""
+
+TABLE_METADATA_QUERY = """
+SELECT tab.table_id, tab.table_title, tab.universe, tab.denominator_column_id,
+       col.column_id, col.column_title, col.indent
+  FROM census_column_metadata col
+  LEFT JOIN census_table_metadata tab USING (table_id)
+ WHERE table_id IN :table_ids
+ ORDER BY column_id;
+"""
+
+
+def _geometry_from_request(payload):
+    """Pull a single GeoJSON geometry (Polygon/MultiPolygon) out of the request
+    body, unwrapping a Feature if necessary. Returns a JSON string suitable for
+    ST_GeomFromGeoJSON, or None if nothing usable was supplied."""
+    geom = payload.get('geometry')
+    if not geom or not isinstance(geom, dict):
+        return None
+    gtype = geom.get('type')
+    if gtype == 'Feature':
+        geom = geom.get('geometry')
+        if not isinstance(geom, dict):
+            return None
+        gtype = geom.get('type')
+    if gtype not in ('Polygon', 'MultiPolygon'):
+        # FeatureCollections must be dissolved to a single geometry client-side.
+        return None
+    return json.dumps(geom)
+
+
+def _fetch_acs_table_data(release, table_ids, geo_ids):
+    """For a single ACS release, fetch table metadata and per-geography
+    estimate/error data for the given geoids. Returns (table_metadata, data)
+    where data[geoid][table_id] = {"estimate": {...}, "error": {...}}.
+
+    Mirrors the fetch performed by show_specified_data for one release; kept
+    separate to avoid disturbing that endpoint's multi-release fallback logic.
+    """
+    db.session.execute(text("SET search_path=:acs, public;"), {'acs': release})
+
+    result = db.session.execute(text(TABLE_METADATA_QUERY),
+                                {'table_ids': tuple(table_ids)})
+    table_metadata = OrderedDict()
+    for table, columns in groupby(
+            result.mappings().all(),
+            lambda x: (x['table_id'], x['table_title'], x['universe'], x['denominator_column_id'])):
+        table_metadata[table[0]] = OrderedDict([
+            ("title", table[1]),
+            ("universe", table[2]),
+            ("denominator_column_id", table[3]),
+            ("columns", OrderedDict([
+                (column['column_id'], OrderedDict([
+                    ("name", column['column_title']),
+                    ("indent", column['indent']),
+                ])) for column in columns
+            ])),
+        ])
+
+    valid_table_ids = list(table_metadata.keys())
+    invalid_table_ids = set(table_ids) - set(valid_table_ids)
+    if invalid_table_ids:
+        abort(404, "The %s release doesn't include table(s) %s."
+              % (get_acs_name(release), ','.join(sorted(invalid_table_ids))))
+
+    from_stmt = '%s_moe' % valid_table_ids[0]
+    for table_id in valid_table_ids[1:]:
+        from_stmt += ' JOIN %s_moe USING (geoid)' % table_id
+    sql = 'SELECT * FROM %s WHERE geoid IN :geoids;' % from_stmt
+
+    result = db.session.execute(text(sql), {'geoids': tuple(geo_ids)})
+    data = OrderedDict()
+    for row in result.mappings().all():
+        row = dict(row)
+        geoid = row.pop('geoid')
+        data_for_geoid = OrderedDict()
+        # Estimate columns and their paired _moe columns arrive adjacent once
+        # sorted; a shared iterator lets us pull each moe with next().
+        cols_iter = iter(sorted(row.items(), key=lambda tup: tup[0]))
+        for table_id, data_iter in groupby(cols_iter, lambda x: x[0][:-3].upper()):
+            table_for_geoid = OrderedDict()
+            table_for_geoid['estimate'] = OrderedDict()
+            table_for_geoid['error'] = OrderedDict()
+            for (col_name, value) in data_iter:
+                col_name = col_name.upper()
+                (_moe_name, moe_value) = next(cols_iter)
+                table_for_geoid['estimate'][col_name] = value
+                table_for_geoid['error'][col_name] = moe_value
+            data_for_geoid[table_id] = table_for_geoid
+        data[geoid] = data_for_geoid
+
+    return table_metadata, data
+
+
+# Example: POST /1.0/aggregate/acs/acs2024_5yr
+#   body: {"geometry": {...GeoJSON Polygon...}, "table_ids": ["B01001"],
+#          "sumlevel": "140", "threshold": 0.0}
+@app.route("/1.0/aggregate/acs/<release>", methods=['POST', 'OPTIONS'])
+@cross_origin(origins='*')
+def aggregate_acs_geometry(release):
+    if release == 'latest':
+        release = allowed_acs[0]
+    if release not in allowed_acs:
+        abort(404, "The %s release isn't supported." % get_acs_name(release))
+
+    payload = request.get_json(force=True, silent=True) or {}
+
+    geojson_str = _geometry_from_request(payload)
+    if geojson_str is None:
+        abort(400, "A GeoJSON Polygon or MultiPolygon 'geometry' is required.")
+
+    table_ids = payload.get('table_ids') or []
+    if not table_ids or not all(table_re.match(t) for t in table_ids):
+        abort(400, "One or more valid 'table_ids' are required.")
+
+    sumlevel = str(payload.get('sumlevel', '')).strip()
+    if sumlevel not in SUMLEV_NAMES:
+        abort(400, "A valid 'sumlevel' is required (e.g. 140 for tracts).")
+
+    try:
+        threshold = float(payload.get('threshold', 0.0))
+    except (TypeError, ValueError):
+        abort(400, "'threshold' must be a number between 0 and 1.")
+    if not (0.0 <= threshold <= 1.0):
+        abort(400, "'threshold' must be between 0 and 1.")
+
+    tiger = allowed_tiger[0]
+    rows = db.session.execute(
+        text(AGGREGATE_INTERSECT_SQL.format(tiger=tiger)),
+        {'geojson': geojson_str, 'sumlevel': sumlevel}
+    ).mappings().all()
+
+    components = select_components(rows, threshold)
+    if not components:
+        abort(404, "No %s geographies met the threshold inside the given geometry."
+              % SUMLEV_NAMES[sumlevel]['name'])
+
+    max_geoids = current_app.config.get('MAX_GEOIDS_TO_SHOW', 1000)
+    if len(components) > max_geoids:
+        abort(400, "The geometry covers %s geographies at this level; the maximum "
+              "is %s. Use a coarser summary level or a smaller area."
+              % (len(components), max_geoids))
+
+    geo_ids = [c['geoid'] for c in components]
+    table_metadata, data = _fetch_acs_table_data(release, table_ids, geo_ids)
+
+    component_data = [data[g] for g in geo_ids if g in data]
+    aggregated = aggregate_tables(component_data, table_metadata)
+
+    resp = jsonify(
+        release=release,
+        release_name=ACS_NAMES.get(release, {}).get('name', release),
+        sumlevel=sumlevel,
+        threshold=threshold,
+        components=components,
+        tables=aggregated,
+    )
+    resp.cache_control.max_age = 15
+    resp.cache_control.public = True
+    return resp
 
 
 # Example: /1.0/data/download/acs2012_5yr?format=shp&table_ids=B01001,B01003&geo_ids=04000US55,04000US56

--- a/census_extractomatic/moe.py
+++ b/census_extractomatic/moe.py
@@ -1,0 +1,62 @@
+"""Margin-of-error (MoE) aggregation math for combining ACS estimates across
+multiple census geographies.
+
+Pure functions, no database or Flask dependency, so they can be unit-tested in
+isolation. Formulas follow the U.S. Census Bureau guidance in "Understanding and
+Using American Community Survey Data: What All Data Users Need to Know".
+"""
+import math
+
+
+def aggregate_count(estimates, moes):
+    """Aggregate (sum) a set of count estimates and propagate their MoE.
+
+    estimate = sum(estimates)
+    moe      = sqrt(sum(moe_i ** 2))
+
+    Census zero-estimate rule: when one or more components have an estimate of
+    zero, only the single largest MoE among those zero-estimate components is
+    kept (the rest are dropped) so the aggregate MoE is not overstated.
+
+    Returns a (estimate, moe) tuple.
+    """
+    total = sum(estimates)
+
+    nonzero_moes = [m for e, m in zip(estimates, moes) if e != 0]
+    zero_moes = [m for e, m in zip(estimates, moes) if e == 0]
+    kept_moes = list(nonzero_moes)
+    if zero_moes:
+        kept_moes.append(max(zero_moes))
+
+    moe = math.sqrt(sum(m ** 2 for m in kept_moes))
+    return total, moe
+
+
+def derived_ratio(num, num_moe, den, den_moe):
+    """MoE of a ratio R = num / den where num is NOT a subset of den.
+
+        MoE_R = sqrt(num_moe^2 + R^2 * den_moe^2) / den
+
+    Returns a (ratio, moe) tuple.
+    """
+    ratio = num / den
+    moe = math.sqrt(num_moe ** 2 + ratio ** 2 * den_moe ** 2) / den
+    return ratio, moe
+
+
+def derived_proportion(num, num_moe, den, den_moe):
+    """MoE of a proportion p = num / den where num IS a subset of den.
+
+        MoE_p = sqrt(num_moe^2 - p^2 * den_moe^2) / den
+
+    If the radicand is negative, the Census Bureau instructs falling back to the
+    ratio formula (use + instead of -) to avoid a sqrt of a negative number.
+
+    Returns a (proportion, moe) tuple.
+    """
+    p = num / den
+    radicand = num_moe ** 2 - p ** 2 * den_moe ** 2
+    if radicand < 0:
+        return derived_ratio(num, num_moe, den, den_moe)
+    moe = math.sqrt(radicand) / den
+    return p, moe

--- a/census_extractomatic/test_aggregate_acs.py
+++ b/census_extractomatic/test_aggregate_acs.py
@@ -1,0 +1,88 @@
+"""Unit tests for the DB-independent ACS aggregation orchestration
+(census_extractomatic.aggregate_acs): column suppression and table aggregation
+over a set of component geographies."""
+import math
+
+from census_extractomatic.aggregate_acs import suppression_reason, aggregate_tables
+
+
+def test_median_column_is_suppressed():
+    reason = suppression_reason(
+        table_title="Median Household Income in the Past 12 Months",
+        column_title="Median household income in the past 12 months",
+    )
+    assert reason is not None
+    assert "median" in reason.lower()
+
+
+def test_mean_and_per_capita_and_gini_are_suppressed():
+    assert suppression_reason("Mean Travel Time to Work", "Mean travel time") is not None
+    assert suppression_reason("Per Capita Income", "Per capita income") is not None
+    assert suppression_reason("Gini Index of Income Inequality", "Gini index") is not None
+
+
+def test_plain_count_column_is_not_suppressed():
+    assert suppression_reason("Sex by Age", "Male: 5 to 9 years") is None
+
+
+def test_aggregate_word_is_not_suppressed():
+    """'Aggregate' totals (e.g. Aggregate Household Income) ARE summable."""
+    assert suppression_reason("Aggregate Household Income", "Aggregate household income") is None
+
+
+def _two_components():
+    return [
+        {"B01001": {"estimate": {"B01001001": 100, "B01001002": 40},
+                    "error": {"B01001001": 20, "B01001002": 10}}},
+        {"B01001": {"estimate": {"B01001001": 200, "B01001002": 0},
+                    "error": {"B01001001": 30, "B01001002": 8}}},
+    ]
+
+
+_COUNT_META = {
+    "B01001": {
+        "title": "Sex by Age",
+        "denominator_column_id": "B01001001",
+        "columns": {
+            "B01001001": {"name": "Total"},
+            "B01001002": {"name": "Male"},
+        },
+    }
+}
+
+
+def test_aggregate_tables_sums_counts_and_propagates_moe():
+    result = aggregate_tables(_two_components(), _COUNT_META)
+    b = result["B01001"]
+    assert b["estimate"]["B01001001"] == 300
+    assert math.isclose(b["error"]["B01001001"], math.sqrt(20**2 + 30**2))
+
+
+def test_aggregate_tables_applies_zero_estimate_rule_per_column():
+    """B01001002 has estimates [40, 0]; the zero component keeps only its own
+    (single) MoE, giving sqrt(10^2 + 8^2)."""
+    result = aggregate_tables(_two_components(), _COUNT_META)
+    b = result["B01001"]
+    assert b["estimate"]["B01001002"] == 40
+    assert math.isclose(b["error"]["B01001002"], math.sqrt(10**2 + 8**2))
+
+
+def test_aggregate_tables_suppresses_median_column():
+    components = [
+        {"B19013": {"estimate": {"B19013001": 55000}, "error": {"B19013001": 2500}}},
+        {"B19013": {"estimate": {"B19013001": 61000}, "error": {"B19013001": 3100}}},
+    ]
+    metadata = {
+        "B19013": {
+            "title": "Median Household Income in the Past 12 Months",
+            "denominator_column_id": None,
+            "columns": {"B19013001": {"name": "Median household income"}},
+        }
+    }
+    result = aggregate_tables(components, metadata)
+    b = result["B19013"]
+    # The median column must NOT appear in the aggregated estimates...
+    assert "B19013001" not in b["estimate"]
+    # ...and must be reported as suppressed with a reason.
+    suppressed_ids = [s["column_id"] for s in b["suppressed"]]
+    assert "B19013001" in suppressed_ids

--- a/census_extractomatic/test_aggregate_acs.py
+++ b/census_extractomatic/test_aggregate_acs.py
@@ -3,7 +3,11 @@
 over a set of component geographies."""
 import math
 
-from census_extractomatic.aggregate_acs import suppression_reason, aggregate_tables
+from census_extractomatic.aggregate_acs import (
+    suppression_reason,
+    aggregate_tables,
+    select_components,
+)
 
 
 def test_median_column_is_suppressed():
@@ -86,3 +90,44 @@ def test_aggregate_tables_suppresses_median_column():
     # ...and must be reported as suppressed with a reason.
     suppressed_ids = [s["column_id"] for s in b["suppressed"]]
     assert "B19013001" in suppressed_ids
+
+
+def _rows():
+    return [
+        {"full_geoid": "14000US36061000100", "display_name": "Tract A", "area_frac": 1.0},
+        {"full_geoid": "14000US36061000200", "display_name": "Tract B", "area_frac": 0.02},
+        {"full_geoid": "14000US36061000300", "display_name": "Tract C", "area_frac": 0.6},
+    ]
+
+
+def test_aggregate_tables_skips_none_valued_components():
+    """A component with a None estimate/MoE for a column (release has no value)
+    is left out of that column's aggregate rather than crashing the sum."""
+    components = [
+        {"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}},
+        {"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}},
+    ]
+    metadata = {
+        "B01001": {"title": "Sex by Age", "denominator_column_id": "B01001001",
+                   "columns": {"B01001001": {"name": "Total"}}}
+    }
+    result = aggregate_tables(components, metadata)
+    b = result["B01001"]
+    assert b["estimate"]["B01001001"] == 100
+    assert math.isclose(b["error"]["B01001001"], 20.0)
+
+
+def test_select_components_threshold_zero_keeps_all_intersecting():
+    comps = select_components(_rows(), threshold=0.0)
+    assert [c["geoid"] for c in comps] == [
+        "14000US36061000100", "14000US36061000200", "14000US36061000300"
+    ]
+    assert comps[0]["name"] == "Tract A"
+    assert comps[0]["area_frac"] == 1.0
+
+
+def test_select_components_threshold_filters_below_cutoff():
+    comps = select_components(_rows(), threshold=0.5)
+    assert [c["geoid"] for c in comps] == [
+        "14000US36061000100", "14000US36061000300"
+    ]

--- a/census_extractomatic/test_moe.py
+++ b/census_extractomatic/test_moe.py
@@ -1,0 +1,91 @@
+"""Unit tests for the MoE aggregation math (census_extractomatic.moe).
+
+These are pure-function tests with no database dependency. Expected values come
+from published U.S. Census Bureau worked examples in "Understanding and Using
+American Community Survey Data: What All Data Users Need to Know" (Appendix on
+calculating measures of error for derived estimates).
+"""
+import math
+
+from census_extractomatic.moe import (
+    aggregate_count,
+    derived_proportion,
+    derived_ratio,
+)
+
+
+def test_aggregate_count_canonical_handbook_example():
+    """Census handbook: aggregating people 60 to 66 years old.
+
+        60 and 61 years: estimate 1,626, MoE 254
+        62 to 64 years:  estimate 1,244, MoE 209
+        65 and 66 years:  estimate   796, MoE 187
+
+    Aggregate estimate = 3,666; aggregate MoE = sqrt(254^2+209^2+187^2) ~= 378.
+    """
+    est, moe = aggregate_count(
+        estimates=[1626, 1244, 796],
+        moes=[254, 209, 187],
+    )
+    assert est == 3666
+    assert round(moe) == 378
+    assert math.isclose(moe, math.sqrt(254**2 + 209**2 + 187**2))
+
+
+def test_aggregate_count_zero_estimate_rule():
+    """Census rule: when summing counts where one or more components are zero,
+    include only the SINGLE LARGEST MoE among the zero-estimate components (drop
+    the rest) to avoid overstating the aggregate MoE.
+
+        estimates [0, 0, 25], MoEs [8, 12, 40]
+        -> keep the nonzero MoE (40) plus only the largest zero MoE (12)
+        -> MoE = sqrt(12^2 + 40^2)
+    """
+    est, moe = aggregate_count(estimates=[0, 0, 25], moes=[8, 12, 40])
+    assert est == 25
+    assert math.isclose(moe, math.sqrt(12**2 + 40**2))
+
+
+def test_aggregate_count_all_zero_estimates():
+    """All components zero: only the single largest MoE survives."""
+    est, moe = aggregate_count(estimates=[0, 0, 0], moes=[8, 12, 10])
+    assert est == 0
+    assert moe == 12
+
+
+def test_derived_proportion():
+    """Proportion p = X/Y where the numerator X is a subset of denominator Y.
+
+        MoE_p = sqrt(MoE_X^2 - p^2 * MoE_Y^2) / Y
+
+    X=100 (MoE 20), Y=500 (MoE 30) -> p=0.2,
+    MoE_p = sqrt(400 - 0.04*900)/500 = sqrt(364)/500 ~= 0.03815757
+    """
+    p, moe = derived_proportion(num=100, num_moe=20, den=500, den_moe=30)
+    assert math.isclose(p, 0.2)
+    assert math.isclose(moe, 0.038157568056677825)
+
+
+def test_derived_proportion_negative_radicand_falls_back_to_ratio():
+    """When MoE_X^2 - p^2*MoE_Y^2 < 0, fall back to the ratio formula
+    (use + instead of -) to avoid taking sqrt of a negative number.
+
+    X=100 (MoE 5), Y=500 (MoE 100) -> radicand 25 - 400 = -375 < 0,
+    MoE = sqrt(25 + 0.04*10000)/500 = sqrt(425)/500 ~= 0.04123106
+    """
+    p, moe = derived_proportion(num=100, num_moe=5, den=500, den_moe=100)
+    assert math.isclose(p, 0.2)
+    assert math.isclose(moe, 0.04123105625617661)
+
+
+def test_derived_ratio():
+    """Ratio R = X/Y where X is NOT a subset of Y.
+
+        MoE_R = sqrt(MoE_X^2 + R^2 * MoE_Y^2) / Y
+
+    X=100 (MoE 20), Y=50 (MoE 10) -> R=2.0,
+    MoE_R = sqrt(400 + 4*100)/50 = sqrt(800)/50 ~= 0.56568542
+    """
+    r, moe = derived_ratio(num=100, num_moe=20, den=50, den_moe=10)
+    assert math.isclose(r, 2.0)
+    assert math.isclose(moe, 0.5656854249492381)


### PR DESCRIPTION
Backend for computing ACS values over an arbitrary user-supplied geometry, propagating margins of error correctly.

## What this adds
- `census_extractomatic/moe.py` — pure MoE math: count sum with the Census **zero-estimate rule**, derived proportion (with negative-radicand ratio fallback), derived ratio. Verified against the Census handbook's worked example (age 60–66 aggregation → estimate 3,666, MoE 378).
- `census_extractomatic/aggregate_acs.py` — DB-independent orchestration: component selection by area-fraction threshold, table aggregation, and **suppression of non-additive columns** (medians, means, per-capita, Gini) so they're never summed.
- `POST /1.0/aggregate/acs/<release>` — takes a GeoJSON polygon + `table_ids` + `sumlevel` + `threshold`, finds the overlapping geographies via PostGIS `ST_Intersects`, fetches their estimates/MoE, and returns aggregated `estimate`/`error` per column plus the component list.
- 16 unit tests for the pure logic (`test_moe.py`, `test_aggregate_acs.py`), all passing.

## How overlap works
Whole-geography inclusion decided by real polygon intersection (not centroids), with a user-adjustable area-fraction `threshold` (default 0 = any intersection). Estimates are summed; MoE = √Σ MoE² with the zero-estimate rule.

## Not yet verified
The Flask endpoint itself needs a live PostGIS/ACS database to exercise end-to-end (the environment here can run the pure-function tests but not the full app). The MoE math and aggregation/suppression logic are fully unit-tested.