### PR TITLE
Optional area (overlap) weighting for arbitrary-geometry ACS aggregation

### DIFF
--- a/census_extractomatic/aggregate_acs.py
+++ b/census_extractomatic/aggregate_acs.py
@@ -52,18 +52,19 @@ def select_components(rows, threshold=0.0):
     return components
 
 
-def aggregate_tables(components, metadata, weights=None):
+def aggregate_tables(components, metadata):
     """Aggregate ACS tables across a list of component geographies.
 
-    When ``weights`` is given (a list parallel to ``components``), each
-    geography's contribution is apportioned by its weight (overlap fraction).
-    Weights stay aligned with the components that actually contribute to a given
-    column, so a component skipped for missing data also drops its weight.
+    Each component carries its own optional ``weight`` alongside its data, so the
+    weight can never drift out of alignment with the geography it belongs to::
 
-    ``components`` is a list (one entry per component geography) shaped like the
-    per-geography portion of the ``/1.0/data/show`` response::
+        {"weight": 0.37,  # optional; defaults to 1 (whole-geography)
+         "data": {table_id: {"estimate": {col: value}, "error": {col: value}}}}
 
-        {table_id: {"estimate": {col: value}, "error": {col: value}}}
+    The ``data`` portion is shaped like the per-geography portion of the
+    ``/1.0/data/show`` response. When a weight is given, that geography's
+    contribution is apportioned by it (overlap fraction); a component skipped for
+    missing data naturally drops its weight along with it.
 
     ``metadata`` maps table_id -> {"title", "denominator_column_id", "columns":
     {col: {"name": column_title}}}.
@@ -77,9 +78,6 @@ def aggregate_tables(components, metadata, weights=None):
     columns (medians, means, per-capita, index) are never summed; they are listed
     in ``suppressed`` instead.
     """
-    if weights is None:
-        weights = [1] * len(components)
-
     result = {}
     for table_id, table_meta in metadata.items():
         table_title = table_meta.get("title")
@@ -99,8 +97,8 @@ def aggregate_tables(components, metadata, weights=None):
             col_estimates = []
             col_moes = []
             col_weights = []
-            for component, weight in zip(components, weights):
-                table_data = component.get(table_id)
+            for component in components:
+                table_data = component["data"].get(table_id)
                 if not table_data:
                     continue
                 est_value = table_data["estimate"][column_id]
@@ -111,7 +109,7 @@ def aggregate_tables(components, metadata, weights=None):
                     continue
                 col_estimates.append(est_value)
                 col_moes.append(moe_value)
-                col_weights.append(weight)
+                col_weights.append(component.get("weight", 1))
 
             est, moe = aggregate_count(col_estimates, col_moes, weights=col_weights)
             estimates[column_id] = est

--- a/census_extractomatic/aggregate_acs.py
+++ b/census_extractomatic/aggregate_acs.py
@@ -52,8 +52,13 @@ def select_components(rows, threshold=0.0):
     return components
 
 
-def aggregate_tables(components, metadata):
+def aggregate_tables(components, metadata, weights=None):
     """Aggregate ACS tables across a list of component geographies.
+
+    When ``weights`` is given (a list parallel to ``components``), each
+    geography's contribution is apportioned by its weight (overlap fraction).
+    Weights stay aligned with the components that actually contribute to a given
+    column, so a component skipped for missing data also drops its weight.
 
     ``components`` is a list (one entry per component geography) shaped like the
     per-geography portion of the ``/1.0/data/show`` response::
@@ -72,6 +77,9 @@ def aggregate_tables(components, metadata):
     columns (medians, means, per-capita, index) are never summed; they are listed
     in ``suppressed`` instead.
     """
+    if weights is None:
+        weights = [1] * len(components)
+
     result = {}
     for table_id, table_meta in metadata.items():
         table_title = table_meta.get("title")
@@ -90,7 +98,8 @@ def aggregate_tables(components, metadata):
 
             col_estimates = []
             col_moes = []
-            for component in components:
+            col_weights = []
+            for component, weight in zip(components, weights):
                 table_data = component.get(table_id)
                 if not table_data:
                     continue
@@ -102,8 +111,9 @@ def aggregate_tables(components, metadata):
                     continue
                 col_estimates.append(est_value)
                 col_moes.append(moe_value)
+                col_weights.append(weight)
 
-            est, moe = aggregate_count(col_estimates, col_moes)
+            est, moe = aggregate_count(col_estimates, col_moes, weights=col_weights)
             estimates[column_id] = est
             errors[column_id] = moe
 

--- a/census_extractomatic/api.py
+++ b/census_extractomatic/api.py
@@ -1797,6 +1797,10 @@ def aggregate_acs_geometry(release):
     if not (0.0 <= threshold <= 1.0):
         abort(400, "'threshold' must be between 0 and 1.")
 
+    weighting = str(payload.get('weighting', 'none')).lower()
+    if weighting not in ('none', 'area'):
+        abort(400, "'weighting' must be 'none' or 'area'.")
+
     tiger = allowed_tiger[0]
     rows = db.session.execute(
         text(AGGREGATE_INTERSECT_SQL.format(tiger=tiger)),
@@ -1817,8 +1821,14 @@ def aggregate_acs_geometry(release):
     geo_ids = [c['geoid'] for c in components]
     table_metadata, data = _fetch_acs_table_data(release, table_ids, geo_ids)
 
-    component_data = [data[g] for g in geo_ids if g in data]
-    aggregated = aggregate_tables(component_data, table_metadata)
+    # Keep component data and weights aligned to the same geoid order.
+    kept = [c for c in components if c['geoid'] in data]
+    component_data = [data[c['geoid']] for c in kept]
+    if weighting == 'area':
+        weights = [c['area_frac'] for c in kept]
+    else:
+        weights = None
+    aggregated = aggregate_tables(component_data, table_metadata, weights=weights)
 
     # Flatten column metadata so the client can label columns and indent them.
     column_meta = OrderedDict()
@@ -1831,6 +1841,7 @@ def aggregate_acs_geometry(release):
         release_name=ACS_NAMES.get(release, {}).get('name', release),
         sumlevel=sumlevel,
         threshold=threshold,
+        weighting=weighting,
         components=components,
         tables=aggregated,
         column_meta=column_meta,

--- a/census_extractomatic/api.py
+++ b/census_extractomatic/api.py
@@ -1821,14 +1821,16 @@ def aggregate_acs_geometry(release):
     geo_ids = [c['geoid'] for c in components]
     table_metadata, data = _fetch_acs_table_data(release, table_ids, geo_ids)
 
-    # Keep component data and weights aligned to the same geoid order.
-    kept = [c for c in components if c['geoid'] in data]
-    component_data = [data[c['geoid']] for c in kept]
-    if weighting == 'area':
-        weights = [c['area_frac'] for c in kept]
-    else:
-        weights = None
-    aggregated = aggregate_tables(component_data, table_metadata, weights=weights)
+    # Bundle each geography's data with its own weight so they can't desync.
+    component_data = []
+    for c in components:
+        if c['geoid'] not in data:
+            continue
+        entry = {'data': data[c['geoid']]}
+        if weighting == 'area':
+            entry['weight'] = c['area_frac']
+        component_data.append(entry)
+    aggregated = aggregate_tables(component_data, table_metadata)
 
     # Flatten column metadata so the client can label columns and indent them.
     column_meta = OrderedDict()

--- a/census_extractomatic/moe.py
+++ b/census_extractomatic/moe.py
@@ -8,22 +8,34 @@ Using American Community Survey Data: What All Data Users Need to Know".
 import math
 
 
-def aggregate_count(estimates, moes):
+def aggregate_count(estimates, moes, weights=None):
     """Aggregate (sum) a set of count estimates and propagate their MoE.
 
-    estimate = sum(estimates)
-    moe      = sqrt(sum(moe_i ** 2))
+    Unweighted (whole-geography):
+        estimate = sum(estimates)
+        moe      = sqrt(sum(moe_i ** 2))
+
+    Weighted (overlap apportionment), when ``weights`` is given:
+        estimate = sum(w_i * est_i)
+        moe      = sqrt(sum((w_i * moe_i) ** 2))
+    Scaling an estimate by a constant scales its MoE by the same constant, so the
+    MoE math stays valid; the modelling caveat (does the weight really reflect
+    how the variable is distributed?) lives with the caller.
 
     Census zero-estimate rule: when one or more components have an estimate of
-    zero, only the single largest MoE among those zero-estimate components is
-    kept (the rest are dropped) so the aggregate MoE is not overstated.
+    zero, only the single largest (scaled) MoE among those zero-estimate
+    components is kept so the aggregate MoE is not overstated.
 
     Returns a (estimate, moe) tuple.
     """
-    total = sum(estimates)
+    if weights is None:
+        weights = [1] * len(estimates)
 
-    nonzero_moes = [m for e, m in zip(estimates, moes) if e != 0]
-    zero_moes = [m for e, m in zip(estimates, moes) if e == 0]
+    total = sum(w * e for w, e in zip(weights, estimates))
+
+    scaled_moes = [w * m for w, m in zip(weights, moes)]
+    nonzero_moes = [sm for e, sm in zip(estimates, scaled_moes) if e != 0]
+    zero_moes = [sm for e, sm in zip(estimates, scaled_moes) if e == 0]
     kept_moes = list(nonzero_moes)
     if zero_moes:
         kept_moes.append(max(zero_moes))

--- a/census_extractomatic/test_aggregate_acs.py
+++ b/census_extractomatic/test_aggregate_acs.py
@@ -34,12 +34,20 @@ def test_aggregate_word_is_not_suppressed():
     assert suppression_reason("Aggregate Household Income", "Aggregate household income") is None
 
 
-def _two_components():
+def _component(data, weight=None):
+    """Build a component; weight is optional and defaults to 1 when omitted."""
+    c = {"data": data}
+    if weight is not None:
+        c["weight"] = weight
+    return c
+
+
+def _two_components(weights=(None, None)):
     return [
-        {"B01001": {"estimate": {"B01001001": 100, "B01001002": 40},
-                    "error": {"B01001001": 20, "B01001002": 10}}},
-        {"B01001": {"estimate": {"B01001001": 200, "B01001002": 0},
-                    "error": {"B01001001": 30, "B01001002": 8}}},
+        _component({"B01001": {"estimate": {"B01001001": 100, "B01001002": 40},
+                               "error": {"B01001001": 20, "B01001002": 10}}}, weights[0]),
+        _component({"B01001": {"estimate": {"B01001001": 200, "B01001002": 0},
+                               "error": {"B01001001": 30, "B01001002": 8}}}, weights[1]),
     ]
 
 
@@ -73,8 +81,8 @@ def test_aggregate_tables_applies_zero_estimate_rule_per_column():
 
 def test_aggregate_tables_suppresses_median_column():
     components = [
-        {"B19013": {"estimate": {"B19013001": 55000}, "error": {"B19013001": 2500}}},
-        {"B19013": {"estimate": {"B19013001": 61000}, "error": {"B19013001": 3100}}},
+        _component({"B19013": {"estimate": {"B19013001": 55000}, "error": {"B19013001": 2500}}}),
+        _component({"B19013": {"estimate": {"B19013001": 61000}, "error": {"B19013001": 3100}}}),
     ]
     metadata = {
         "B19013": {
@@ -101,8 +109,8 @@ def _rows():
 
 
 def test_aggregate_tables_with_weights():
-    """Per-component weights apportion each geography's contribution."""
-    result = aggregate_tables(_two_components(), _COUNT_META, weights=[0.5, 1.0])
+    """Each component's own weight apportions its contribution."""
+    result = aggregate_tables(_two_components(weights=(0.5, 1.0)), _COUNT_META)
     b = result["B01001"]
     # B01001001 estimates [100, 200] weighted 0.5/1.0 -> 250
     assert math.isclose(b["estimate"]["B01001001"], 250.0)
@@ -110,17 +118,17 @@ def test_aggregate_tables_with_weights():
 
 
 def test_aggregate_tables_weights_align_after_skipping_none():
-    """A skipped (None) component drops its weight too, so weights stay aligned
-    with the components that actually contribute to each column."""
+    """A skipped (None) component drops its weight too, because the weight lives
+    with the component that actually contributes to each column."""
     components = [
-        {"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}},
-        {"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}},
+        _component({"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}}, 0.5),
+        _component({"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}}, 1.0),
     ]
     metadata = {
         "B01001": {"title": "Sex by Age", "denominator_column_id": "B01001001",
                    "columns": {"B01001001": {"name": "Total"}}}
     }
-    result = aggregate_tables(components, metadata, weights=[0.5, 1.0])
+    result = aggregate_tables(components, metadata)
     b = result["B01001"]
     # Only the first component contributes: 0.5 * 100 = 50, moe 0.5 * 20 = 10
     assert math.isclose(b["estimate"]["B01001001"], 50.0)
@@ -131,8 +139,8 @@ def test_aggregate_tables_skips_none_valued_components():
     """A component with a None estimate/MoE for a column (release has no value)
     is left out of that column's aggregate rather than crashing the sum."""
     components = [
-        {"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}},
-        {"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}},
+        _component({"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}}),
+        _component({"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}}),
     ]
     metadata = {
         "B01001": {"title": "Sex by Age", "denominator_column_id": "B01001001",

--- a/census_extractomatic/test_aggregate_acs.py
+++ b/census_extractomatic/test_aggregate_acs.py
@@ -100,6 +100,33 @@ def _rows():
     ]
 
 
+def test_aggregate_tables_with_weights():
+    """Per-component weights apportion each geography's contribution."""
+    result = aggregate_tables(_two_components(), _COUNT_META, weights=[0.5, 1.0])
+    b = result["B01001"]
+    # B01001001 estimates [100, 200] weighted 0.5/1.0 -> 250
+    assert math.isclose(b["estimate"]["B01001001"], 250.0)
+    assert math.isclose(b["error"]["B01001001"], math.sqrt((0.5 * 20) ** 2 + (1.0 * 30) ** 2))
+
+
+def test_aggregate_tables_weights_align_after_skipping_none():
+    """A skipped (None) component drops its weight too, so weights stay aligned
+    with the components that actually contribute to each column."""
+    components = [
+        {"B01001": {"estimate": {"B01001001": 100}, "error": {"B01001001": 20}}},
+        {"B01001": {"estimate": {"B01001001": None}, "error": {"B01001001": None}}},
+    ]
+    metadata = {
+        "B01001": {"title": "Sex by Age", "denominator_column_id": "B01001001",
+                   "columns": {"B01001001": {"name": "Total"}}}
+    }
+    result = aggregate_tables(components, metadata, weights=[0.5, 1.0])
+    b = result["B01001"]
+    # Only the first component contributes: 0.5 * 100 = 50, moe 0.5 * 20 = 10
+    assert math.isclose(b["estimate"]["B01001001"], 50.0)
+    assert math.isclose(b["error"]["B01001001"], 10.0)
+
+
 def test_aggregate_tables_skips_none_valued_components():
     """A component with a None estimate/MoE for a column (release has no value)
     is left out of that column's aggregate rather than crashing the sum."""

--- a/census_extractomatic/test_moe.py
+++ b/census_extractomatic/test_moe.py
@@ -53,6 +53,31 @@ def test_aggregate_count_all_zero_estimates():
     assert moe == 12
 
 
+def test_aggregate_count_with_weights():
+    """Weighted (apportioned) sum: estimate = sum(w_i * est_i),
+    moe = sqrt(sum((w_i * moe_i)^2)).
+
+    estimates [100, 200], moes [20, 30], weights [0.5, 1.0]
+      estimate = 50 + 200 = 250
+      moe = sqrt((0.5*20)^2 + (1.0*30)^2) = sqrt(100 + 900) = sqrt(1000)
+    """
+    est, moe = aggregate_count([100, 200], [20, 30], weights=[0.5, 1.0])
+    assert math.isclose(est, 250.0)
+    assert math.isclose(moe, math.sqrt(1000))
+
+
+def test_aggregate_count_with_weights_applies_zero_rule_on_scaled_moes():
+    """The zero-estimate rule keeps only the largest SCALED moe among zero cells.
+
+    estimates [0, 0, 25], moes [8, 12, 40], weights [0.5, 1.0, 0.5]
+      scaled zero moes: 4, 12 -> keep 12; nonzero scaled moe: 20
+      estimate = 12.5; moe = sqrt(20^2 + 12^2) = sqrt(544)
+    """
+    est, moe = aggregate_count([0, 0, 25], [8, 12, 40], weights=[0.5, 1.0, 0.5])
+    assert math.isclose(est, 12.5)
+    assert math.isclose(moe, math.sqrt(544))
+
+
 def test_derived_proportion():
     """Proportion p = X/Y where the numerator X is a subset of denominator Y.
 


### PR DESCRIPTION
Follow-up to #94. Adds an opt-in `weighting` mode to `POST /1.0/aggregate/acs/<release>`.

## What
- `weighting` request field: `none` (default, unchanged whole-geography behavior) or `area`.
- When `area`, each component geography's estimate is apportioned by its overlap fraction (`area_frac`): `estimate = Σ wᵢ·estᵢ`, `moe = √Σ(wᵢ·moeᵢ)²`. Scaling an estimate by a constant scales its MoE by the same constant, so the MoE math stays valid (the Census zero-estimate rule is applied to the *scaled* MoEs).
- Weights stay aligned with the components that actually contribute to each column (a component skipped for missing data drops its weight too).
- Response echoes `weighting`.

## Caveat (documented in code)
Area weighting assumes the variable is distributed uniformly across each geography's area — often false where density varies. Opt-in; surfaced in the UI as *approximate*. Population/dasymetric weighting would be more accurate and is a possible phase 2.

## Tests
`weights` threaded through `aggregate_count` and `aggregate_tables`; 20 unit tests pass (4 new, incl. scaled zero-estimate rule and weight/None alignment).

**Must be merged + deployed for the companion censusreporter frontend toggle to have any effect** — until then production ignores `weighting`.